### PR TITLE
Check response from doHTTPGet() before use

### DIFF
--- a/weather.go
+++ b/weather.go
@@ -173,7 +173,9 @@ func (c *Client) doHTTP(req *http.Request) (*http.Response, error) {
 // process HTTP response
 // Unmarshall received data into holder struct
 func processHTTPResponse(resp *http.Response, err error, holder interface{}) error {
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The response from doHTTPGet() needs to be checked before using it. Otherwise this can occur:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x70cc11]

goroutine 58627 [running]:
github.com/exzz/netatmo-api-go.processHTTPResponse(0x0, 0xa06d00, 0xc000468030, 0x8d3820, 0xc0004f6d80, 0x0, 0x0)
        /go/pkg/mod/github.com/exzz/netatmo-api-go@v0.0.0-20171026152754-41589231f446/weather.go:176 +0x41
github.com/exzz/netatmo-api-go.(*Client).Read(0xc0004f6d60, 0x5fbc6114, 0x245cb11f, 0x312f8772ba9ba6)
        /go/pkg/mod/github.com/exzz/netatmo-api-go@v0.0.0-20171026152754-41589231f446/weather.go:204 +0x16a
```
Please check my syntax. I am not a Go programmer.